### PR TITLE
feat: Allow @api_view wrapped functions as well.

### DIFF
--- a/hybridrouter/tests/views.py
+++ b/hybridrouter/tests/views.py
@@ -1,3 +1,4 @@
+from rest_framework.decorators import api_view
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from .models import Item
@@ -9,3 +10,10 @@ class ItemView(APIView):
         items = Item.objects.all()
         serializer = ItemSerializer(items, many=True)
         return Response(serializer.data)
+
+
+@api_view(["GET"])
+def item_view(request):
+    items = Item.objects.all()
+    serializer = ItemSerializer(items, many=True)
+    return Response(serializer.data)


### PR DESCRIPTION
Thank you for making this! I was looking for something like this and was only able to find the older project: https://bitbucket.org/hub9/django-hybrid-router/src/master/ 

It allows both `APIView` and `@api_view` in addition to `ViewSet`s, but I had some issues (mainly not being able to prefix/nest things).

So I came back to your project and made the changes I needed to make it work.

I ran the tests with `poetry run pytest` and they all passed.

Let me know your thoughts!